### PR TITLE
fix and test: [H-01] Erasure of user's vest.amount when redistributedBLB is non-zero.

### DIFF
--- a/src/BlueberryStaking.sol
+++ b/src/BlueberryStaking.sol
@@ -301,7 +301,7 @@ contract BlueberryStaking is
             uint256 _vestEpoch = (vest.startTime - deployedAt) / epochLength;
 
             if (epochs[_vestEpoch].redistributedBLB > 0) {
-                vest.amount =
+                vest.amount +=
                     (vest.amount * epochs[_vestEpoch].redistributedBLB) /
                     epochs[_vestEpoch].totalBLB;
             }

--- a/test/Vesting.t.sol
+++ b/test/Vesting.t.sol
@@ -141,30 +141,32 @@ contract BlueberryStakingTest is Test {
     }
 
     function testEnsureEarlyUnlockRatioLinear() public {
+        // To start, the penalty is 25%. After 364 days (52 weeks), the penalty will be 0%.
         blueberryStaking.startVesting(bTokens);
 
+        // 0/364 days: 100% of original penalty => 25%.
         console2.log("Unlock penalty ratio right away: %s%", blueberryStaking.getEarlyUnlockPenaltyRatio(bob, 0) / 1e16);
+        assertEq(blueberryStaking.getEarlyUnlockPenaltyRatio(bob, 0), 25e16);
 
-        assertEq(blueberryStaking.getEarlyUnlockPenaltyRatio(bob, 0) / 1e16, 25);
-
+        // 10/364 days: 97% of original penalty => ~24%.
         skip(10 days);
-
         console2.log(
             "Unlock penalty ratio after 10 days: %s%", blueberryStaking.getEarlyUnlockPenaltyRatio(bob, 0) / 1e16
         );
+        assertApproxEqAbs(blueberryStaking.getEarlyUnlockPenaltyRatio(bob, 0), 24e16, 1e16);
 
+        // 165/364 days: 55% of original penalty => ~14%.
         skip(155 days);
-
         console2.log(
             "Unlock penalty ratio after 165 days: %s%", blueberryStaking.getEarlyUnlockPenaltyRatio(bob, 0) / 1e16
         );
+        assertApproxEqAbs(blueberryStaking.getEarlyUnlockPenaltyRatio(bob, 0), 14e16, 1e16);
 
-        skip(200 days);
-
+        // 364/364 days: 0% of original penalty => 0%.
+        skip(199 days);
         console2.log(
-            "Unlock penalty ratio after 365 days: %s%", blueberryStaking.getEarlyUnlockPenaltyRatio(bob, 0) / 1e16
+            "Unlock penalty ratio after 364 days: %s%", blueberryStaking.getEarlyUnlockPenaltyRatio(bob, 0) / 1e16
         );
-
         assertEq(blueberryStaking.getEarlyUnlockPenaltyRatio(bob, 0), 0);
     }
 }


### PR DESCRIPTION
# Description

At [BlueberryStaking.sol:303](https://github.com/Blueberryfi/blueberry-stakevest/blob/8d2864e3b0ae5ff718d4fc2527e74c6a35903b72/src/BlueberryStaking.sol#L303-L307), the following code block is intended to distribute some of the `redistributedBLB` to the caller:

```solidity
if (epochs[_vestEpoch].redistributedBLB > 0) {
    vest.amount =
        (vest.amount * epochs[_vestEpoch].redistributedBLB) /
        epochs[_vestEpoch].totalBLB;
}
```

It aims to increase the caller's `vest.amount` proportionally to their share of the total `bdBLB` allocated for the given `_vestEpoch`. However, the code contains a typo which performs a strict assignment (`=`) rather than incrementing (`+=`).

This PR introduces a test that exposes the issue. The test fails at ad7f8c1c276c27cf826fb78da98c479feb6670b1 but succeeds at e65ab91a03bea5f9d62445d9728c9fccde30a803 after introducing the fix to `BlueberryStaking.sol`.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge