### PR TITLE
fix and test: [H-02] Under-distribution of redistributedBLB locks excess BLB in the staking contract.

### DIFF
--- a/src/BlueberryStaking.sol
+++ b/src/BlueberryStaking.sol
@@ -125,12 +125,6 @@ contract BlueberryStaking is
      */
     address[] public ibTokens;
 
-    /**
-     * @notice The extra vest reward due to each user as a result of redistributing BLB during vest acceleration.
-     * @dev This storage variable was added on Mar 7, 2024 as part of a bug-fix upgrade
-     */
-    mapping(address => uint256[]) public vestExtra;
-
     /*//////////////////////////////////////////////////
                         CONSTRUCTOR
     //////////////////////////////////////////////////*/
@@ -296,7 +290,6 @@ contract BlueberryStaking is
         }
 
         Vest[] storage vests = vesting[msg.sender];
-        uint256[] storage extras = vestExtra[msg.sender];
 
         for (uint256 i; i < _vestIndexes.length; ++i) {
             Vest storage vest = vests[_vestIndexes[i]];
@@ -308,7 +301,7 @@ contract BlueberryStaking is
             uint256 _vestEpoch = (vest.startTime - deployedAt) / epochLength;
 
             if (epochs[_vestEpoch].redistributedBLB > 0) {
-                extras[_vestIndexes[i]] = 
+                vest.extra = 
                     (vest.amount * epochs[_vestEpoch].redistributedBLB) /
                     epochs[_vestEpoch].totalBLB;
             }
@@ -346,9 +339,8 @@ contract BlueberryStaking is
                 uint256 _priceUnderlying = getPrice();
 
                 vesting[msg.sender].push(
-                    Vest(reward, block.timestamp, _priceUnderlying)
+                    Vest(reward, 0, block.timestamp, _priceUnderlying)
                 );
-                vestExtra[msg.sender].push(0);
             }
         }
 
@@ -362,7 +354,6 @@ contract BlueberryStaking is
         uint256[] calldata _vestIndexes
     ) external whenNotPaused updateVests(msg.sender, _vestIndexes) {
         Vest[] storage vests = vesting[msg.sender];
-        uint256[] storage extras = vestExtra[msg.sender];
         if (vesting[msg.sender].length < _vestIndexes.length) {
             revert InvalidLength();
         }
@@ -375,14 +366,13 @@ contract BlueberryStaking is
                 revert VestingIncomplete();
             }
 
-            totalbdblb += v.amount + extras[_vestIndexes[i]];
+            totalbdblb += v.amount + v.extra;
 
             // Reduce totalBLB for the corresponding epoch to ensure accurate redistribution accounting.
             uint256 _vestEpoch = (v.startTime - deployedAt) / epochLength;
             epochs[_vestEpoch].totalBLB -= v.amount;
 
             delete vests[_vestIndexes[i]];
-            delete extras[_vestIndexes[i]];
         }
 
         if (totalbdblb > 0) {
@@ -407,7 +397,6 @@ contract BlueberryStaking is
         }
 
         Vest[] storage vests = vesting[msg.sender];
-        uint256[] storage extras = vestExtra[msg.sender];
 
         uint256 totalbdblb;
         uint256 totalRedistributedAmount;
@@ -415,9 +404,9 @@ contract BlueberryStaking is
         for (uint256 i; i < _vestIndexes.length; ++i) {
             uint256 _vestIndex = _vestIndexes[i];
             Vest storage _vest = vests[_vestIndex];
-            uint256 _vestAmount = _vest.amount + extras[_vestIndex];
+            uint256 _vestTotal = _vest.amount + _vest.extra;
 
-            if (_vestAmount <= 0) {
+            if (_vestTotal <= 0) {
                 revert NothingToUpdate();
             }
 
@@ -438,7 +427,7 @@ contract BlueberryStaking is
             totalAccelerationFee += _accelerationFee;
 
             // calculate the amount of the vest that will be redistributed
-            uint256 _redistributionAmount = (_vestAmount *
+            uint256 _redistributionAmount = (_vestTotal *
                 _earlyUnlockPenaltyRatio) / 1e18;
 
             // get current epoch and redistribute to it
@@ -449,10 +438,10 @@ contract BlueberryStaking is
             totalRedistributedAmount += _redistributionAmount;
 
             // remove it from the recieved vest
-            _vestAmount -= _redistributionAmount;
+            _vestTotal -= _redistributionAmount;
 
             // the remainder is withdrawable by the user
-            totalbdblb += _vestAmount;
+            totalbdblb += _vestTotal;
 
             // Reduce totalBLB for the corresponding epoch to ensure accurate redistribution accounting.
             uint256 _vestEpoch = (_vest.startTime - deployedAt) / epochLength;
@@ -460,7 +449,6 @@ contract BlueberryStaking is
 
             // delete the vest
             delete vests[_vestIndex];
-            delete extras[_vestIndex];
         }
 
         if (totalAccelerationFee > 0) {
@@ -630,7 +618,7 @@ contract BlueberryStaking is
     function bdblbBalance(address _user) public view returns (uint256) {
         uint256 _balance;
         for (uint256 i; i < vesting[_user].length; ++i) {
-            _balance += vesting[_user][i].amount + vestExtra[_user][i];
+            _balance += vesting[_user][i].amount + vesting[_user][i].extra;
         }
         return _balance;
     }
@@ -669,8 +657,7 @@ contract BlueberryStaking is
         uint256 _vestingScheduleIndex
     ) public view returns (uint256 accelerationFee) {
         Vest storage _vest = vesting[_user][_vestingScheduleIndex];
-        uint256 _extra = vestExtra[_user][_vestingScheduleIndex];
-        uint256 _vestAmount = _vest.amount + _extra;
+        uint256 _vestTotal = _vest.amount + _vest.extra;
 
         uint256 _earlyUnlockPenaltyRatio = getEarlyUnlockPenaltyRatio(
             _user,
@@ -678,7 +665,7 @@ contract BlueberryStaking is
         );
 
         accelerationFee =
-            ((((_vest.priceUnderlying * _vestAmount) / 1e18) *
+            ((((_vest.priceUnderlying * _vestTotal) / 1e18) *
                 _earlyUnlockPenaltyRatio) / 1e18) /
             (10 ** (18 - stableDecimals));
     }

--- a/src/interfaces/IBlueberryStaking.sol
+++ b/src/interfaces/IBlueberryStaking.sol
@@ -117,11 +117,13 @@ interface IBlueberryStaking {
     /**
      * @dev Struct to store info related to a vesting schedule
      * @param amount The amount of tokens vested
+     * @param extra The extra amount of tokens to be redistributed to this vesting schedule
      * @param startTime The start time of the vesting schedule
      * @param priceUnderlying The underlying token Price
      */
     struct Vest {
         uint256 amount;
+        uint256 extra;
         uint256 startTime;
         uint256 priceUnderlying;
     }

--- a/test/Vesting.t.sol
+++ b/test/Vesting.t.sol
@@ -98,18 +98,16 @@ contract BlueberryStakingTest is Test {
         vm.stopPrank();
 
         console.log("BLB balance before: %s", blb.balanceOf(address(this)));
-
-        // 3. bob starts vesting after 14 days of rewards accrual
-        skip(14 days);
-        vm.prank(bob);
-        blueberryStaking.startVesting(bTokens);
     }
 
     function testAccelerateVestingMonthOne() public {
-        // Bob has just started vesting (see `setUp()`).
         vm.startPrank(bob);
 
-        // 3. 1/2 a year has now passed, bob decides to accelerate his vesting
+        // 3. bob starts vesting after 14 days of rewards accrual
+        skip(14 days);
+        blueberryStaking.startVesting(bTokens);
+
+        // 4. 1/2 a year has now passed, bob decides to accelerate his vesting
 
         vm.warp(180 days);
 
@@ -143,7 +141,11 @@ contract BlueberryStakingTest is Test {
     }
 
     function testEnsureEarlyUnlockRatioLinear() public {
-        // Bob has just started vesting (see `setUp()`).
+        // 3. bob starts vesting after 14 days of rewards accrual
+        skip(14 days);
+        vm.prank(bob);
+        blueberryStaking.startVesting(bTokens);
+
         // To start, the penalty is 25%. After 364 days (52 weeks), the penalty will be 0%.
 
         // 0/364 days: 100% of original penalty => 25%.
@@ -173,13 +175,15 @@ contract BlueberryStakingTest is Test {
     }
 
     function testAccelerateVestingTwoUsers() public {
-        // Bob has just started vesting (see `setUp()`).
+        vm.startPrank(bob);
+
+        // 3. bob starts vesting after 14 days of rewards accrual
+        skip(14 days);
+        blueberryStaking.startVesting(bTokens);
         (uint256 bobVestAmount, , ) = blueberryStaking.vesting(bob, 0);
 
         // Wait 60 days to guarantee lockdrop completes.
         skip(60 days);
-
-        vm.startPrank(bob);
 
         // Bob accelerates, paying an early unlock penalty and acceleration fee.
         uint256[] memory indexes = new uint256[](1);
@@ -200,6 +204,58 @@ contract BlueberryStakingTest is Test {
         vm.startPrank(sally);
 
         // Sally now starts vesting within the same epoch that Bob redistributed some BLB.
+        blueberryStaking.startVesting(bTokens);
+        (uint256 sallyVestAmount, , ) = blueberryStaking.vesting(sally, 0);
+
+        // Wait 52 weeks to enable Sally to complete her vesting.
+        skip(52 weeks);
+
+        // Sally completes her vesting. She should have received her vest amount plus Bob's redistributed BLB.
+        blueberryStaking.completeVesting(indexes);
+        uint256 sallyBLB = blb.balanceOf(sally);
+        console2.log("Sally's vest amount was: %s", sallyVestAmount);
+        console2.log("Sally received: %s", sallyBLB);
+        assertEq(sallyBLB, sallyVestAmount + redistributedBLB);
+
+        vm.stopPrank();
+
+        // In total, Bob and Sally should have received all of the vested rewards.
+        uint256 totalVestAmount = bobVestAmount + sallyVestAmount;
+        uint256 totalBLB = bobBLB + sallyBLB;
+        console2.log("Together, Bob and Sally earned: %s", totalVestAmount);
+        console2.log("Together, Bob and Sally received: %s", totalBLB);
+        assertEq(totalBLB, totalVestAmount);
+    }
+
+    function testAccelerateVestingTwoUsersSameEpoch() public {
+        vm.startPrank(bob);
+
+        // Wait 60 days to guarantee lockdrop completes.
+        skip(60 days + 1);
+
+        // Bob starts vesting.
+        blueberryStaking.startVesting(bTokens);
+        (uint256 bobVestAmount, , ) = blueberryStaking.vesting(bob, 0);
+
+        // Bob immediately accelerates, paying the full early unlock penalty and acceleration fee.
+        uint256[] memory indexes = new uint256[](1);
+        uint256 bobPenalty = blueberryStaking.getEarlyUnlockPenaltyRatio(bob, 0);
+        mockUSDC.approve(address(blueberryStaking), 1e6 * 10_000);
+        blueberryStaking.accelerateVesting(indexes);
+
+        // Bob should have received his vest amount minus the early unlock penalty.
+        uint256 redistributedBLB = bobPenalty * bobVestAmount / 1e18;
+        uint256 bobBLB = blb.balanceOf(bob);
+        console2.log("Bob's vest amount was: %s", bobVestAmount);
+        console2.log("Bob's penalty amount was: %s", redistributedBLB);
+        console2.log("Bob received: %s", bobBLB);
+        assertEq(bobBLB, bobVestAmount - redistributedBLB);
+
+        vm.stopPrank();
+
+        vm.startPrank(sally);
+
+        // Sally now starts vesting within the same epoch that Bob vested and redistributed some BLB.
         blueberryStaking.startVesting(bTokens);
         (uint256 sallyVestAmount, , ) = blueberryStaking.vesting(sally, 0);
 

--- a/test/Vesting.t.sol
+++ b/test/Vesting.t.sol
@@ -121,7 +121,7 @@ contract BlueberryStakingTest is Test {
         console.log("USDC balance before acceleration 1/2 year in: $%s", mockUSDC.balanceOf(bob) / 1e6);
         console.log("Acceleration Ratio: %s%", blueberryStaking.getEarlyUnlockPenaltyRatio(bob, 0) / 1e15);
 
-        (uint256 vestAmount,, uint256 underlyingCost) = blueberryStaking.vesting(bob, 0);
+        (uint256 vestAmount, , , uint256 underlyingCost) = blueberryStaking.vesting(bob, 0);
         uint256 _earlyUnlockRatio = (blueberryStaking.getEarlyUnlockPenaltyRatio(bob, 0));
         uint256 _expectedCost = (_earlyUnlockRatio * ((underlyingCost * vestAmount) / 1e18) / 1e18) / 1e12;
         uint256 _accelerationFee = (blueberryStaking.getAccelerationFeeStableAsset(bob, 0));
@@ -180,7 +180,7 @@ contract BlueberryStakingTest is Test {
         // 3. bob starts vesting after 14 days of rewards accrual
         skip(14 days);
         blueberryStaking.startVesting(bTokens);
-        (uint256 bobVestAmount, , ) = blueberryStaking.vesting(bob, 0);
+        (uint256 bobVestAmount, , , ) = blueberryStaking.vesting(bob, 0);
 
         // Wait 60 days to guarantee lockdrop completes.
         skip(60 days);
@@ -205,7 +205,7 @@ contract BlueberryStakingTest is Test {
 
         // Sally now starts vesting within the same epoch that Bob redistributed some BLB.
         blueberryStaking.startVesting(bTokens);
-        (uint256 sallyVestAmount, , ) = blueberryStaking.vesting(sally, 0);
+        (uint256 sallyVestAmount, , , ) = blueberryStaking.vesting(sally, 0);
 
         // Wait 52 weeks to enable Sally to complete her vesting.
         skip(52 weeks);
@@ -235,7 +235,7 @@ contract BlueberryStakingTest is Test {
 
         // Bob starts vesting.
         blueberryStaking.startVesting(bTokens);
-        (uint256 bobVestAmount, , ) = blueberryStaking.vesting(bob, 0);
+        (uint256 bobVestAmount, , , ) = blueberryStaking.vesting(bob, 0);
 
         // Bob immediately accelerates, paying the full early unlock penalty and acceleration fee.
         uint256[] memory indexes = new uint256[](1);
@@ -257,7 +257,7 @@ contract BlueberryStakingTest is Test {
 
         // Sally now starts vesting within the same epoch that Bob vested and redistributed some BLB.
         blueberryStaking.startVesting(bTokens);
-        (uint256 sallyVestAmount, , ) = blueberryStaking.vesting(sally, 0);
+        (uint256 sallyVestAmount, , , ) = blueberryStaking.vesting(sally, 0);
 
         // Wait 52 weeks to enable Sally to complete her vesting.
         skip(52 weeks);


### PR DESCRIPTION
# Description

When a user calls `startVesting()`, the value of `epochs[n].totalBLB` is incremented to account for the new balance of `bdBLB`. But when `BLB` tokens are distributed to the caller of either `startVesting()` or `accelerateVesting()`, the value of `epochs[n].totalBLB` remains unchanged.

If `epochs[n].totalBLB` is not reduced when a user's `bdBLB` position is destroyed, this will negatively impact the accounting of redistributed `BLB` tokens in `updateVests()`:

```solidity
// Hypothetical version of this code block after merging PR #7.
if (epochs[_vestEpoch].redistributedBLB > 0) {
    vest.amount +=
        (vest.amount * epochs[_vestEpoch].redistributedBLB) /
        epochs[_vestEpoch].totalBLB;
}
```

The over-valued `epochs[_vestEpoch].totalBLB` will ensure that `epochs[_vestEpoch].redistributedBLB` is never fully distributed. Whatever tokens remain after all vested positions are closed will be locked in the `BlueberryStaking` contract unless it is upgraded.

This PR introduces a test that exposes the issue. The test fails at 01ffb0e4ea2654187322efb38a669c913d78a4cf but succeeds at 78ba09e1c808b02426c4fbdeb7a15eb9b5e10a59 after introducing the fix to BlueberryStaking.sol.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge