### PR TITLE
fix: [M08] Under-distribution of redistributedBLB if no user vests in the corresponding epoch.

### DIFF
--- a/src/interfaces/IBlueberryStaking.sol
+++ b/src/interfaces/IBlueberryStaking.sol
@@ -28,8 +28,6 @@ interface IBlueberryStaking {
 
     error NothingToAccelerate();
 
-    error InvalidEpoch();
-
     error LockDropActive();
 
     error LockDropInactive();
@@ -72,8 +70,6 @@ interface IBlueberryStaking {
 
     error IbTokenDoesNotExist();
 
-    error EpochLengthZero();
-
     error ArrayAlreadySet();
 
     /*//////////////////////////////////////////////////
@@ -95,8 +91,6 @@ interface IBlueberryStaking {
     event Accelerated(address indexed user, uint256 tokensClaimed, uint256 redistributedBLB);
 
     event VestingCompleted(address indexed user, uint256 amount, uint256 timestamp);
-
-    event EpochLengthUpdated(uint256 epochLength, uint256 timestamp);
 
     event BasePenaltyRatioChanged(uint256 basePenaltyRatio, uint256 timestamp);
 
@@ -126,16 +120,6 @@ interface IBlueberryStaking {
         uint256 extra;
         uint256 startTime;
         uint256 priceUnderlying;
-    }
-
-    /**
-     * @dev Struct to store info related to a Epoch
-     * @param redistributedBLB The amount of BLB redistributed in the epoch
-     * @param totalBLB The total amount of BLB in the epoch
-     */
-    struct Epoch {
-        uint256 redistributedBLB;
-        uint256 totalBLB;
     }
 
     /*//////////////////////////////////////////////////
@@ -201,13 +185,6 @@ interface IBlueberryStaking {
      * @return _price The current price using 6 decimal points
      */
     function getPrice() external view returns (uint256 _price);
-
-    /**
-     * @notice ensures the user can only claim rewards once per epoch
-     * @param _user the user to check
-     * @return returns true if the user can claim, false otherwise
-     */
-    function canClaim(address _user) external view returns (bool);
 
     /**
      * @return returns true if the vesting schedule is complete for the given user and vesting index
@@ -304,11 +281,6 @@ interface IBlueberryStaking {
      * @param _ibTokens An array of the tokens to add
      */
     function addIbTokens(address[] calldata _ibTokens) external;
-
-    /**
-     * @notice Change the epoch length in seconds
-     */
-    function changeEpochLength(uint256 _epochLength) external;
 
     /**
      * @notice Change the blb token address (in case of migration)

--- a/test/Control.t.sol
+++ b/test/Control.t.sol
@@ -140,15 +140,6 @@ contract Control is Test {
         );
     }
 
-    // Test changing the epoch length
-    function testChangeEpochLength() public {
-        vm.startPrank(owner);
-
-        // Change the epoch length and verify the updated value
-        blueberryStaking.changeEpochLength(70_420_248_412);
-        assertEq(blueberryStaking.epochLength(), 70_420_248_412);
-    }
-
     // Test changing the BLB token address
     function testChangeBLB() public {
         vm.startPrank(owner);

--- a/test/Staking.t.sol
+++ b/test/Staking.t.sol
@@ -89,7 +89,7 @@ contract BlueberryStakingTest is Test {
         uint256[] memory stakeAmounts = new uint256[](1);
         address[] memory bTokens = new address[](1);
 
-        // 1. Notify the new rewards amount (1e18 * 20) for the first epoch
+        // 1. Notify the new rewards amount (1e18 * 20) for the reward period
 
         vm.startPrank(owner);
 
@@ -111,11 +111,11 @@ contract BlueberryStakingTest is Test {
 
         blueberryStaking.stake(bTokens, stakeAmounts);
 
-        // 3. Half an epoch passes and it becomes claimable
+        // 3. Half the reward period passes and it becomes claimable
 
         skip(7 days);
 
-        // 3.5 Ensure that the rewards are half of the total rewards given that half of an epoch has passed
+        // 3.5 Ensure that the rewards are half of the total rewards given that half of the reward period has passed
 
         console2.log("bob earned: %s", blueberryStaking.earned(address(bob), address(mockbToken1)));
 
@@ -187,7 +187,7 @@ contract BlueberryStakingTest is Test {
         uint256[] memory stakeAmounts = new uint256[](1);
         address[] memory bTokens = new address[](1);
 
-        // 1. Notify the new rewards amount (1e18 * 20) for the first epoch
+        // 1. Notify the new rewards amount (1e18 * 20) for the reward period
 
         vm.startPrank(owner);
 
@@ -227,7 +227,7 @@ contract BlueberryStakingTest is Test {
 
         vm.stopPrank();
 
-        // 3. The entire epoch passes thus all rewards are claimable
+        // 3. The entire reward period passes thus all rewards are claimable
 
         skip(14 days);
 
@@ -284,7 +284,7 @@ contract BlueberryStakingTest is Test {
         uint256[] memory stakeAmounts = new uint256[](1);
         address[] memory bTokens = new address[](1);
 
-        // 1. Notify the new rewards amount 20 tokens for the first epoch
+        // 1. Notify the new rewards amount 20 tokens for the reward period
 
         vm.startPrank(owner);
 
@@ -329,7 +329,7 @@ contract BlueberryStakingTest is Test {
         uint256[] memory sallyStakeAmounts = new uint256[](1);
         address[] memory sallybTokens = new address[](1);
 
-        // 1. Notify the new rewards amount 20 tokens for the first epoch
+        // 1. Notify the new rewards amount 20 tokens for the reward period
 
         vm.startPrank(owner);
 

--- a/test/Vesting.t.sol
+++ b/test/Vesting.t.sol
@@ -85,7 +85,7 @@ contract BlueberryStakingTest is Test {
 
         vm.stopPrank();
 
-        // 1. Notify the new rewards amount 4_000 of each token for the epoch
+        // 1. Notify the new rewards amount 4_000 of each token for the reward period
 
         vm.startPrank(owner);
 
@@ -198,7 +198,7 @@ contract BlueberryStakingTest is Test {
         assertEq(blueberryStaking.getEarlyUnlockPenaltyRatio(bob, 0), 0);
     }
 
-    function testAccelerateVestingTwoUsers() public {
+    function testAccelerateVestingTwoUsersSequential() public {
         vm.startPrank(bob);
 
         // 3. bob starts vesting after 14 days of rewards accrual
@@ -227,7 +227,7 @@ contract BlueberryStakingTest is Test {
 
         vm.startPrank(sally);
 
-        // Sally now starts vesting within the same epoch that Bob redistributed some BLB.
+        // Sally now starts vesting.
         blueberryStaking.startVesting(bTokens);
         (uint256 sallyVestAmount, , , ) = blueberryStaking.vesting(sally, 0);
 
@@ -251,7 +251,7 @@ contract BlueberryStakingTest is Test {
         assertEq(totalBLB, totalVestAmount);
     }
 
-    function testAccelerateVestingTwoUsersSameEpoch() public {
+    function testAccelerateVestingTwoUsersSimultaneous() public {
         vm.startPrank(bob);
 
         // Wait 60 days to guarantee lockdrop completes.
@@ -279,7 +279,7 @@ contract BlueberryStakingTest is Test {
 
         vm.startPrank(sally);
 
-        // Sally now starts vesting within the same epoch that Bob vested and redistributed some BLB.
+        // Sally now starts vesting.
         blueberryStaking.startVesting(bTokens);
         (uint256 sallyVestAmount, , , ) = blueberryStaking.vesting(sally, 0);
 
@@ -303,7 +303,7 @@ contract BlueberryStakingTest is Test {
         assertEq(totalBLB, totalVestAmount);
     }
 
-    function testAccelerateVestingSameEpochStaggered() public {
+    function testAccelerateVestingStaggered() public {
         // Wait 60 days to guarantee lockdrop completes.
         skip(60 days + 1);
 


### PR DESCRIPTION
# Description

Accelerated vest penalties are served from one user to other users via `epochs[n].redistributedBLB`. When a user calls `accelerateVesting()` at some epoch N, some `BLB` rewards are earmarked for all other vesters who opened their positions in that same epoch N.

The system does not account for the possibility that not a single user vested at epoch N, or that all existing vests in epoch N are closed via acceleration. In these cases, some `redistributedBLB` will be accounted but never distributed to users, thus locking `BLB` tokens in the contract.

Notably, the epoch system is not used outside of vest acceleration. Epochs do not factor into staking, reward rates, or fully vested positions. The same accounting of `redistributedBLB` and `totalBLB` should (after fixing #8 and #9) be possible at a global level instead of per-epoch, and this would ensure that all `redistributedBLB` are eventually distributed (unless the very last remaining vester chooses to accelerate their position).

This PR completely removes the epoch system and reframes acceleration accounting as two global variables: `totalVestAmount` and `redistributedBLB`. It does not add any new tests but verifies that all existing tests pass even with such a foundational change.

Removing the epoch system also addresses these other findings which are related to epochs:
- [M-07] Undefined behavior: if epoch length changes after vesting has already begun, all prior epoch-based accounting will be invalidated.
- [L-04] The canClaim() function provides no protection as it always returns true.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge