### PR TITLE
[M-01] Missing _disableInitializers() in constructor of upgradeable implementation contract.

### DIFF
--- a/src/BlueberryStaking.sol
+++ b/src/BlueberryStaking.sol
@@ -123,7 +123,11 @@ contract BlueberryStaking is
     /*//////////////////////////////////////////////////
                         CONSTRUCTOR
     //////////////////////////////////////////////////*/
-    constructor() {}
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
 
     /*//////////////////////////////////////////////////
                      FUNCTIONS


### PR DESCRIPTION
# Description

This PR resolves finding M-01 in the most recent audit of `BlueberryStaking` done by @cuthalion0x, that highlights the fact that `_disableInitializers` is missing from the constructor. OpenZeppelin recommends adding this to the implementation contract behind upgradeable proxies. While this vulnerability is most critical for UUPS proxies it is standard practice to include it in all proxies just for extra security. 

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
