### PR TITLE
[L-08] Incoming ETH is locked in the contract unless it is upgraded to enable transfers.

### DIFF
--- a/src/BlueberryStaking.sol
+++ b/src/BlueberryStaking.sol
@@ -828,8 +828,4 @@ contract BlueberryStaking is
             }
         }
     }
-
-    receive() external payable {}
-
-    fallback() external payable {}
 }


### PR DESCRIPTION
# Description

The `BlueberryStaking` contract includes empty `receive()` and `fallback()` functions to accept incoming `ETH` donations, but it lacks the capability to invoke `address.call()`, `address.send()`, or `address.transfer()` to do anything with donated `ETH`. A contract upgrade would be required to enable this functionality.

This update removes the `receive()` and `fallback()` functions because it is completely unnecessary for this contract to receive `ETH` donations.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
