### PR TITLE
[L-07] The maximum basePenaltyRatioPercent should be 50% rather than 100% because the fee is double-charged.

### DIFF
--- a/src/BlueberryStaking.sol
+++ b/src/BlueberryStaking.sol
@@ -746,7 +746,7 @@ contract BlueberryStaking is
 
     /// @inheritdoc IBlueberryStaking
     function setBasePenaltyRatioPercent(uint256 _ratio) external onlyOwner {
-        if (_ratio > 1e18) {
+        if (_ratio > 0.5e18) {
             revert InvalidPenaltyRatio();
         }
         basePenaltyRatioPercent = _ratio;


### PR DESCRIPTION
# Description

The `setBasePenaltyRatioPercent()` function constrains `basePenaltyRatioPercent` between `0` and `1e18`. Within this code base, a fee of `1e18` is equivalent to a fee of 100% of principal value. Due to the fact that the fee is assessed twice: once as the early withdrawal penalty denominated in `BLB` token rewards, and again as the acceleration fee denominated in stable coins.

This PR updates the maximum `basePenaltyRatioPercent` able to be set to `0.5e18`.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206771725059567