### PR TITLE
[M-04] Miscalculated rewardRate due to premature update of finishAt.

### DIFF
--- a/src/BlueberryStaking.sol
+++ b/src/BlueberryStaking.sol
@@ -723,9 +723,10 @@ contract BlueberryStaking is
                 revert InvalidRewardRate();
             }
 
-            finishAt = block.timestamp + rewardDuration;
             lastUpdateTime[_ibToken] = block.timestamp;
         }
+
+        finishAt = block.timestamp + rewardDuration;
 
         emit RewardAmountModified(_ibTokens, _amounts, block.timestamp);
     }


### PR DESCRIPTION
# Description

Within the for loop of `modifyRewardAmount` any remaining rewards for each token are reallocated to the new calculation of `rewardPerToken` based on a comparison of that periods `finishAt` timestamp. There is an issue within this block of code however in that the `finishAt` variable is updated within the for loop. This causes only the first token's `rewardPerToken` value to be accurately reflected within the system and overvalues the remainder of the token rewards in the input array. 

To fix this vulnerability we simply just update `finishAt` after the for loop to ensure that the same contract state is being evaluated for all tokens in the array. Respective tests have been added, `Control#testChangeRewardAmount`, that exposes the error by failing before the change has been made and passing after.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
