### PR TITLE
[L-06] Setting reward amounts does not guarantee availability of reward tokens.

### DIFF
--- a/src/BlueberryStaking.sol
+++ b/src/BlueberryStaking.sol
@@ -666,7 +666,7 @@ contract BlueberryStaking is
     ) external onlyOwner {
         _validateTokenAmountsArray(_ibTokens, _amounts);
 
-        uint256 _totalRewards;
+        uint256 _totalRewardsAdded;
         bool _isBeforeFinishAt = (block.timestamp < finishAt);
         uint256 _rewardDuration = rewardDuration;
         
@@ -690,12 +690,12 @@ contract BlueberryStaking is
                 _amount = 0;
             }
 
-            _totalRewards += _amount;
+            _totalRewardsAdded += _amount;
 
             emit IbTokenAdded(_ibToken, _amount, block.timestamp);
         }
 
-        blb.transferFrom(msg.sender, address(this), _totalRewards);
+        blb.transferFrom(msg.sender, address(this), _totalRewardsAdded);
     }
 
     /// @inheritdoc IBlueberryStaking
@@ -723,7 +723,7 @@ contract BlueberryStaking is
     ) external onlyOwner updateRewards(address(0), _ibTokens) {
         _validateTokenAmountsArray(_ibTokens, _amounts);
 
-        uint256 _totalRewards;
+        uint256 _totalRewardsAdded;
         uint256 _rewardDuration = rewardDuration;
         uint256 _ibTokensLength = _ibTokens.length;
 
@@ -742,12 +742,12 @@ contract BlueberryStaking is
 
             finishAt = block.timestamp + _rewardDuration;
             lastUpdateTime[_ibToken] = block.timestamp;
-            _totalRewards += _amount;
+            _totalRewardsAdded += _amount;
 
             emit RewardAmountModified(_ibToken, _amount, block.timestamp);
         }
 
-        blb.transferFrom(msg.sender, address(this), _totalRewards);
+        blb.transferFrom(msg.sender, address(this), _totalRewardsAdded);
     }
 
     /// @inheritdoc IBlueberryStaking

--- a/src/BlueberryStaking.sol
+++ b/src/BlueberryStaking.sol
@@ -666,8 +666,10 @@ contract BlueberryStaking is
     ) external onlyOwner {
         _validateTokenAmountsArray(_ibTokens, _amounts);
 
+        uint256 _totalRewards;
         bool _isBeforeFinishAt = (block.timestamp < finishAt);
         uint256 _rewardDuration = rewardDuration;
+        
         uint256 _length = _ibTokens.length;
         totalIbTokens += _length;
 
@@ -688,8 +690,12 @@ contract BlueberryStaking is
                 _amount = 0;
             }
 
+            _totalRewards += _amount;
+
             emit IbTokenAdded(_ibToken, _amount, block.timestamp);
         }
+
+        blb.transferFrom(msg.sender, address(this), _totalRewards);
     }
 
     /// @inheritdoc IBlueberryStaking
@@ -717,8 +723,10 @@ contract BlueberryStaking is
     ) external onlyOwner updateRewards(address(0), _ibTokens) {
         _validateTokenAmountsArray(_ibTokens, _amounts);
 
+        uint256 _totalRewards;
         uint256 _rewardDuration = rewardDuration;
         uint256 _ibTokensLength = _ibTokens.length;
+
         for (uint256 i; i < _ibTokensLength; ++i) {
             address _ibToken = _ibTokens[i];
             uint256 _amount = _amounts[i];
@@ -734,9 +742,12 @@ contract BlueberryStaking is
 
             finishAt = block.timestamp + _rewardDuration;
             lastUpdateTime[_ibToken] = block.timestamp;
+            _totalRewards += _amount;
 
             emit RewardAmountModified(_ibToken, _amount, block.timestamp);
         }
+
+        blb.transferFrom(msg.sender, address(this), _totalRewards);
     }
 
     /// @inheritdoc IBlueberryStaking

--- a/test/Control.t.sol
+++ b/test/Control.t.sol
@@ -32,7 +32,8 @@ contract Control is Test {
         mockbToken2 = new MockbToken();
         mockbToken3 = new MockbToken();
         mockUSDC = new MockUSDC();
-        blb = new BlueberryToken(address(this), owner, block.timestamp + 30);
+
+        blb = new BlueberryToken(address(this), owner, block.timestamp);
 
         // Initialize existingBTokens array
         existingBTokens = new address[](3);
@@ -62,6 +63,7 @@ contract Control is Test {
         );
 
         blueberryStaking = BlueberryStaking(payable(address(proxy)));
+        blb.approve(address(blueberryStaking), UINT256_MAX);
 
         skip(300);
         blb.mint(address(owner), 1_000_000e18);
@@ -108,7 +110,6 @@ contract Control is Test {
 
         uint256 blbBalance = blb.balanceOf(address(blueberryStaking));
 
-        blb.approve(address(blueberryStaking), UINT256_MAX);
         // Add the new bTokens to the BlueberryStaking contract and update the rewards
         blueberryStaking.addIbTokens(bTokens, rewardAmounts);
 
@@ -187,7 +188,6 @@ contract Control is Test {
         amounts[1] = 1e19 * 4;
         amounts[2] = 1e23 * 4;
 
-        blb.approve(address(blueberryStaking), UINT256_MAX);
         blueberryStaking.modifyRewardAmount(existingBTokens, amounts);
 
         // Check if the reward rates were set correctly

--- a/test/Staking.t.sol
+++ b/test/Staking.t.sol
@@ -50,7 +50,7 @@ contract BlueberryStakingTest is Test {
 
         mockUSDC = new MockUSDC();
 
-        blb = new BlueberryToken(owner, owner, block.timestamp + 30);
+        blb = new BlueberryToken(owner, owner, block.timestamp);
 
         existingBTokens = new address[](3);
 
@@ -78,7 +78,8 @@ contract BlueberryStakingTest is Test {
 
         blueberryStaking = BlueberryStaking(payable(address(proxy)));
 
-        blb.transfer(address(blueberryStaking), 1e20);
+        blb.mint(address(owner), 1e20);
+        blb.approve(address(blueberryStaking), UINT256_MAX);
 
         mockbToken1.transfer(bob, 1e8 * 200);
         mockbToken2.transfer(bob, 1e8 * 200);

--- a/test/Vesting.t.sol
+++ b/test/Vesting.t.sol
@@ -49,7 +49,7 @@ contract BlueberryStakingTest is Test {
 
         mockUSDC = new MockUSDC();
 
-        blb = new BlueberryToken(owner, owner, block.timestamp + 30);
+        blb = new BlueberryToken(owner, owner, block.timestamp);
 
         existingBTokens = new address[](3);
 
@@ -77,7 +77,7 @@ contract BlueberryStakingTest is Test {
 
         blueberryStaking = BlueberryStaking(payable(address(proxy)));
         
-        blb.transfer(address(blueberryStaking), 1e20);
+        blb.mint(address(owner), 1e20);
 
         mockbToken1.transfer(bob, 1e18 * 200);
         mockbToken2.transfer(bob, 1e18 * 200);
@@ -112,6 +112,7 @@ contract BlueberryStakingTest is Test {
 
         bTokens[0] = existingBTokens[0];
 
+        blb.approve(address(blueberryStaking), UINT256_MAX);
         blueberryStaking.modifyRewardAmount(bTokens, rewardAmounts);
 
         vm.stopPrank();


### PR DESCRIPTION
# Description

This branch builds off of PR #16 due to `addIbToken` also setting the `rewardRate` for a given token. 

When `owner` calls `modifyRewardAmount()` or `addIbToken` to set `rewardRate` for each `ibToken`, this activates `rewards` accounting for each user but does not guarantee availability of `BLB` rewards at the future claim time. This is not a smooth interaction for the `owner` and relies on the assumption that the `owner` will accurately transfer enough rewards to the contract to accurately cover all accumulated rewards for users. In order to better operate within the ethos of DeFi and provide users with an increase level of assurance that their rewards are financially backed, this PR transfers `blb` tokens from the `msg.sender` to `BlueberryStaking` anytime reward amounts are modified, either within `modifyRewardAmount` or `addIbToken`.

Tests were added to expose this issue and fail in commit [15945d3](https://github.com/Blueberryfi/blueberry-stakevest/tree/15945d31b3d563739909d873cd371a7d7292a706), before the change was made, and pass in commit [5441427](https://github.com/Blueberryfi/blueberry-stakevest/tree/5441427c394f69757ffc2d8dc54aaeae9b1ad9bb), after the change was made.

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
