### PR TITLE
uint128 conversion fix

### DIFF
--- a/src/BlueberryStaking.sol
+++ b/src/BlueberryStaking.sol
@@ -285,7 +285,9 @@ contract BlueberryStaking is
             }
 
             if (redistributedBLB > 0) {
-                vest.extra = (vest.amount * uint128(redistributedBLB)) / uint128(totalVestAmount);
+                vest.extra = uint128(
+                    (vest.amount * redistributedBLB) / totalVestAmount
+                );
             }
         }
 
@@ -738,11 +740,12 @@ contract BlueberryStaking is
         if (_observationPeriod == 0 || _observationPeriod > 432_000) {
             revert InvalidObservationTime();
         }
-        
-        bool blbIsToken0 = IUniswapV3Pool(_uniswapPool).token0() == address(blb);
+
+        bool blbIsToken0 = IUniswapV3Pool(_uniswapPool).token0() ==
+            address(blb);
 
         if (blbIsToken0) {
-            address token1 =IUniswapV3Pool(_uniswapPool).token1();
+            address token1 = IUniswapV3Pool(_uniswapPool).token1();
             if (token1 != _stableAsset) revert InvalidStableAsset();
             stableAsset = IERC20(token1);
         } else {
@@ -760,7 +763,12 @@ contract BlueberryStaking is
         uint8 decimals = IERC20Metadata(_stableAsset).decimals();
         stableDecimals = decimals;
 
-        emit UniswapV3PoolUpdated(_uniswapPool, _stableAsset, decimals, _observationPeriod);
+        emit UniswapV3PoolUpdated(
+            _uniswapPool,
+            _stableAsset,
+            decimals,
+            _observationPeriod
+        );
     }
 
     /// @notice Pauses the contract
@@ -831,11 +839,13 @@ contract BlueberryStaking is
 
         if (_uniswapV3Info.blbIsToken0) {
             return
-                uint128(FullMath.mulDiv(
-                    _priceX96,
-                    10 ** (18 + BLB_DECIMALS - stableDecimals),
-                    UNISWAP_PRICING_DENOMINATOR
-                ));
+                uint128(
+                    FullMath.mulDiv(
+                        _priceX96,
+                        10 ** (18 + BLB_DECIMALS - stableDecimals),
+                        UNISWAP_PRICING_DENOMINATOR
+                    )
+                );
         } else {
             uint256 inversePrice = FullMath.mulDiv(
                 _priceX96,


### PR DESCRIPTION
# Description

Currently in Blueberry Staking on line 288 there is a `uint128` conversion on `redistributedBLB` that could cause potential overflow issues.  This has now been fixed and only converts values the completion of arithmetic operations.

Also some linting occurs in this PR as well!

## Type of change

- [x] Bug fix <!-- (non-breaking change which fixes an issue) -->
- [ ] New feature <!-- (non-breaking change which adds functionality) -->
- [ ] Breaking change <!-- (would cause existing functionality to not work as expected) -->
- [ ] Dependency changes
- [ ] Code refactor / cleanup
- [ ] Documentation or wording changes
- [ ] Other

## Checklist:

- [x] The diff is legible and has no extraneous changes
- [x] Complex code has been commented, including external interfaces
- [x] Tests are included for all code paths
- [x] The base branch is either `master`, or there's a description of how to merge

## Issue Resolution

<!-- If this PR addresses an issue, note that here: e.g., Closes/Fixes/Resolves #1346. -->
